### PR TITLE
[#17] タスク登録機能の実装（バリデーション＋登録フォームUI）

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -50,6 +50,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/backend/src/main/java/com/taskmanagement/controller/TaskController.java
+++ b/backend/src/main/java/com/taskmanagement/controller/TaskController.java
@@ -1,7 +1,9 @@
 package com.taskmanagement.controller;
 
+import com.taskmanagement.dto.TaskRequest;
 import com.taskmanagement.entity.Task;
 import com.taskmanagement.service.TaskService;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -23,8 +25,8 @@ public class TaskController {
     }
 
     @PostMapping
-    public Task createTask(@RequestBody Task task) {
-        return taskService.create(task);
+    public Task createTask(@Valid @RequestBody TaskRequest request) {
+        return taskService.create(request);
     }
 
     @PutMapping("/{id}")

--- a/backend/src/main/java/com/taskmanagement/dto/TaskRequest.java
+++ b/backend/src/main/java/com/taskmanagement/dto/TaskRequest.java
@@ -1,0 +1,29 @@
+package com.taskmanagement.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+import java.time.LocalDate;
+
+public class TaskRequest {
+
+    @NotBlank(message = "タイトルは必須です")
+    private String title;
+
+    private String memo;
+
+    private LocalDate dueDate;
+
+    private String genre;
+
+    public String getTitle() { return title; }
+    public void setTitle(String title) { this.title = title; }
+
+    public String getMemo() { return memo; }
+    public void setMemo(String memo) { this.memo = memo; }
+
+    public LocalDate getDueDate() { return dueDate; }
+    public void setDueDate(LocalDate dueDate) { this.dueDate = dueDate; }
+
+    public String getGenre() { return genre; }
+    public void setGenre(String genre) { this.genre = genre; }
+}

--- a/backend/src/main/java/com/taskmanagement/service/TaskService.java
+++ b/backend/src/main/java/com/taskmanagement/service/TaskService.java
@@ -1,5 +1,6 @@
 package com.taskmanagement.service;
 
+import com.taskmanagement.dto.TaskRequest;
 import com.taskmanagement.entity.Task;
 import com.taskmanagement.repository.TaskRepository;
 import org.springframework.stereotype.Service;
@@ -19,7 +20,12 @@ public class TaskService {
         return taskRepository.findAll();
     }
 
-    public Task create(Task task) {
+    public Task create(TaskRequest request) {
+        Task task = new Task();
+        task.setTitle(request.getTitle());
+        task.setMemo(request.getMemo());
+        task.setDueDate(request.getDueDate());
+        task.setGenre(request.getGenre());
         return taskRepository.save(task);
     }
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -155,3 +155,102 @@ body {
   color: #d97706;
   font-weight: 600;
 }
+
+/* Board container */
+.board-container {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+/* TaskForm */
+.task-form {
+  background: #fff;
+  border-radius: 12px;
+  padding: 20px 24px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
+  max-width: 600px;
+}
+
+.task-form-title {
+  font-size: 16px;
+  font-weight: 700;
+  color: #374151;
+  margin-bottom: 16px;
+}
+
+.task-form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 12px;
+}
+
+.task-form-field label {
+  font-size: 13px;
+  font-weight: 600;
+  color: #374151;
+}
+
+.task-form-field input[type="text"],
+.task-form-field input[type="date"],
+.task-form-field textarea,
+.task-form-field select {
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  padding: 8px 10px;
+  font-size: 14px;
+  color: #111827;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.task-form-field input:focus,
+.task-form-field textarea:focus,
+.task-form-field select:focus {
+  border-color: #2563eb;
+}
+
+.task-form-field textarea {
+  resize: vertical;
+}
+
+.task-form-row {
+  display: flex;
+  gap: 16px;
+}
+
+.task-form-row .task-form-field {
+  flex: 1;
+}
+
+.required {
+  color: #dc2626;
+}
+
+.task-form-error {
+  color: #dc2626;
+  font-size: 13px;
+  margin-bottom: 10px;
+}
+
+.task-form-submit {
+  background: #2563eb;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 9px 20px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.task-form-submit:hover:not(:disabled) {
+  background: #1d4ed8;
+}
+
+.task-form-submit:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/frontend/src/api/taskApi.js
+++ b/frontend/src/api/taskApi.js
@@ -1,3 +1,5 @@
 import axios from 'axios';
 
 export const fetchTasks = () => axios.get('/api/tasks').then((r) => r.data);
+
+export const createTask = (data) => axios.post('/api/tasks', data).then((r) => r.data);

--- a/frontend/src/components/Board.jsx
+++ b/frontend/src/components/Board.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { fetchTasks } from '../api/taskApi';
 import Column from './Column';
+import TaskForm from './TaskForm';
 
 const GENRES = ['仕事', '家庭', '趣味', '買い物', '未設定'];
 
@@ -16,6 +17,10 @@ function Board() {
       .finally(() => setLoading(false));
   }, []);
 
+  const handleTaskCreated = (newTask) => {
+    setTasks((prev) => [...prev, newTask]);
+  };
+
   if (loading) return <p className="board-message">読み込み中...</p>;
   if (error) return <p className="board-message error">{error}</p>;
 
@@ -27,10 +32,13 @@ function Board() {
   }, {});
 
   return (
-    <div className="board">
-      {GENRES.map((genre) => (
-        <Column key={genre} genre={genre} tasks={tasksByGenre[genre]} />
-      ))}
+    <div className="board-container">
+      <TaskForm onCreated={handleTaskCreated} />
+      <div className="board">
+        {GENRES.map((genre) => (
+          <Column key={genre} genre={genre} tasks={tasksByGenre[genre]} />
+        ))}
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/TaskForm.jsx
+++ b/frontend/src/components/TaskForm.jsx
@@ -1,0 +1,98 @@
+import { useState } from 'react';
+import { createTask } from '../api/taskApi';
+
+const GENRES = ['仕事', '家庭', '趣味', '買い物'];
+
+function TaskForm({ onCreated }) {
+  const [title, setTitle] = useState('');
+  const [memo, setMemo] = useState('');
+  const [dueDate, setDueDate] = useState('');
+  const [genre, setGenre] = useState('');
+  const [error, setError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!title.trim()) {
+      setError('タイトルを入力してください');
+      return;
+    }
+    setError('');
+    setSubmitting(true);
+    try {
+      const newTask = await createTask({
+        title: title.trim(),
+        memo: memo.trim() || null,
+        dueDate: dueDate || null,
+        genre: genre || null,
+      });
+      setTitle('');
+      setMemo('');
+      setDueDate('');
+      setGenre('');
+      onCreated(newTask);
+    } catch {
+      setError('登録に失敗しました。もう一度お試しください。');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form className="task-form" onSubmit={handleSubmit}>
+      <h2 className="task-form-title">タスクを追加</h2>
+
+      <div className="task-form-field">
+        <label htmlFor="title">タイトル <span className="required">*</span></label>
+        <input
+          id="title"
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="タスクのタイトルを入力"
+        />
+      </div>
+
+      <div className="task-form-field">
+        <label htmlFor="memo">メモ</label>
+        <textarea
+          id="memo"
+          value={memo}
+          onChange={(e) => setMemo(e.target.value)}
+          placeholder="メモ（任意）"
+          rows={3}
+        />
+      </div>
+
+      <div className="task-form-row">
+        <div className="task-form-field">
+          <label htmlFor="dueDate">期限</label>
+          <input
+            id="dueDate"
+            type="date"
+            value={dueDate}
+            onChange={(e) => setDueDate(e.target.value)}
+          />
+        </div>
+
+        <div className="task-form-field">
+          <label htmlFor="genre">ジャンル</label>
+          <select id="genre" value={genre} onChange={(e) => setGenre(e.target.value)}>
+            <option value="">未設定</option>
+            {GENRES.map((g) => (
+              <option key={g} value={g}>{g}</option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {error && <p className="task-form-error">{error}</p>}
+
+      <button type="submit" className="task-form-submit" disabled={submitting}>
+        {submitting ? '登録中...' : '登録する'}
+      </button>
+    </form>
+  );
+}
+
+export default TaskForm;


### PR DESCRIPTION
## 概要

タスクの新規登録機能を実装しました。

Closes #17

## 変更内容

### バックエンド
- `spring-boot-starter-validation` を追加
- `TaskRequest` DTO を新規作成（`title` に `@NotBlank` バリデーション）
- `TaskController.createTask` を `@Valid @RequestBody TaskRequest` に更新
- `TaskService.create` を DTO を受け取るよう更新

### フロントエンド
- `taskApi.js` に `createTask()` 関数を追加
- `TaskForm.jsx` を新規作成（タイトル必須・メモ・期限・ジャンル入力フォーム）
- `Board.jsx` に `TaskForm` を組み込み、登録後に一覧へリアルタイム反映

## バリデーション
- フロント：タイトルが空の場合は即エラー表示（サーバーに送信しない）
- バックエンド：`@NotBlank` でタイトル未入力を400 Bad Requestで弾く

## テスト計画
- [ ] フォームからタスクを登録するとボードに表示される
- [ ] タイトル未入力で登録ボタンを押すとエラーが表示される
- [ ] 登録したタスクがDBに保存されている

🤖 Generated with [Claude Code](https://claude.com/claude-code)