### PR TITLE
[#19] タスクの更新処理を実装（完了トグル・ドラッグ&ドロップ並び替え）

### DIFF
--- a/backend/src/main/java/com/taskmanagement/controller/TaskController.java
+++ b/backend/src/main/java/com/taskmanagement/controller/TaskController.java
@@ -1,5 +1,6 @@
 package com.taskmanagement.controller;
 
+import com.taskmanagement.dto.ReorderRequest;
 import com.taskmanagement.dto.TaskRequest;
 import com.taskmanagement.entity.Task;
 import com.taskmanagement.service.TaskService;
@@ -43,5 +44,11 @@ public class TaskController {
     @PatchMapping("/{id}/complete")
     public Task toggleComplete(@PathVariable Long id) {
         return taskService.toggleComplete(id);
+    }
+
+    @PutMapping("/reorder")
+    public ResponseEntity<Void> reorder(@RequestBody ReorderRequest request) {
+        taskService.reorder(request);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/taskmanagement/dto/ReorderRequest.java
+++ b/backend/src/main/java/com/taskmanagement/dto/ReorderRequest.java
@@ -1,0 +1,26 @@
+package com.taskmanagement.dto;
+
+import java.util.List;
+
+public class ReorderRequest {
+
+    private List<Item> items;
+
+    public List<Item> getItems() { return items; }
+    public void setItems(List<Item> items) { this.items = items; }
+
+    public static class Item {
+        private Long id;
+        private int sortOrder;
+        private String genre;
+
+        public Long getId() { return id; }
+        public void setId(Long id) { this.id = id; }
+
+        public int getSortOrder() { return sortOrder; }
+        public void setSortOrder(int sortOrder) { this.sortOrder = sortOrder; }
+
+        public String getGenre() { return genre; }
+        public void setGenre(String genre) { this.genre = genre; }
+    }
+}

--- a/backend/src/main/java/com/taskmanagement/service/TaskService.java
+++ b/backend/src/main/java/com/taskmanagement/service/TaskService.java
@@ -1,9 +1,11 @@
 package com.taskmanagement.service;
 
+import com.taskmanagement.dto.ReorderRequest;
 import com.taskmanagement.dto.TaskRequest;
 import com.taskmanagement.entity.Task;
 import com.taskmanagement.repository.TaskRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -49,5 +51,16 @@ public class TaskService {
                 .orElseThrow(() -> new RuntimeException("Task not found: " + id));
         task.setCompleted(!task.isCompleted());
         return taskRepository.save(task);
+    }
+
+    @Transactional
+    public void reorder(ReorderRequest request) {
+        for (ReorderRequest.Item item : request.getItems()) {
+            Task task = taskRepository.findById(item.getId())
+                    .orElseThrow(() -> new RuntimeException("Task not found: " + item.getId()));
+            task.setSortOrder(item.getSortOrder());
+            task.setGenre(item.getGenre());
+            taskRepository.save(task);
+        }
     }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@hello-pangea/dnd": "^18.0.1",
         "axios": "^1.15.2",
         "react": "^19.2.5",
         "react-dom": "^19.2.5"
@@ -214,6 +215,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -424,6 +434,23 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@hello-pangea/dnd": {
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/@hello-pangea/dnd/-/dnd-18.0.1.tgz",
+      "integrity": "sha512-xojVWG8s/TGrKT1fC8K2tIWeejJYTAeJuj36zM//yEm/ZrnZUSFGS15BpO+jGZT1ybWvyXmeDJwPYb4dhWlbZQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.26.7",
+        "css-box-model": "^1.2.1",
+        "raf-schd": "^4.0.3",
+        "react-redux": "^9.2.0",
+        "redux": "^5.0.1"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -889,7 +916,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -904,6 +931,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.1",
@@ -1126,11 +1159,20 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-box-model": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
+      "integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
+      "license": "MIT",
+      "dependencies": {
+        "tiny-invariant": "^1.0.6"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -2400,6 +2442,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/raf-schd": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
+      "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
+      "license": "MIT"
+    },
     "node_modules/react": {
       "version": "19.2.5",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
@@ -2420,6 +2468,35 @@
       "peerDependencies": {
         "react": "^19.2.5"
       }
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
     },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.17",
@@ -2511,6 +2588,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -2588,6 +2671,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@hello-pangea/dnd": "^18.0.1",
     "axios": "^1.15.2",
     "react": "^19.2.5",
     "react-dom": "^19.2.5"

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -100,6 +100,12 @@ body {
   flex-direction: column;
   gap: 8px;
   overflow-y: auto;
+  min-height: 60px;
+  transition: background 0.15s;
+}
+
+.column-body.drag-over {
+  background: #dbeafe;
 }
 
 .column-empty {
@@ -115,11 +121,57 @@ body {
   border-radius: 8px;
   padding: 10px 12px;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-  cursor: default;
+  cursor: grab;
+}
+
+.task-card:active {
+  cursor: grabbing;
+}
+
+.task-card.dragging {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+  transform: rotate(1deg);
 }
 
 .task-card.completed {
   opacity: 0.5;
+}
+
+.task-card-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.complete-btn {
+  flex-shrink: 0;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: 2px solid #d1d5db;
+  background: #fff;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 700;
+  color: #9ca3af;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: border-color 0.15s, background 0.15s, color 0.15s;
+  padding: 0;
+  line-height: 1;
+}
+
+.complete-btn.active {
+  border-color: #16a34a;
+  background: #16a34a;
+  color: #fff;
+}
+
+.complete-btn:hover:not(.active) {
+  border-color: #2563eb;
+  color: #2563eb;
 }
 
 .task-title {
@@ -127,7 +179,6 @@ body {
   font-weight: 600;
   color: #111827;
   line-height: 1.4;
-  margin-bottom: 4px;
 }
 
 .task-memo {

--- a/frontend/src/api/taskApi.js
+++ b/frontend/src/api/taskApi.js
@@ -3,3 +3,7 @@ import axios from 'axios';
 export const fetchTasks = () => axios.get('/api/tasks').then((r) => r.data);
 
 export const createTask = (data) => axios.post('/api/tasks', data).then((r) => r.data);
+
+export const toggleComplete = (id) => axios.patch(`/api/tasks/${id}/complete`).then((r) => r.data);
+
+export const reorderTasks = (items) => axios.put('/api/tasks/reorder', { items });

--- a/frontend/src/components/Board.jsx
+++ b/frontend/src/components/Board.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
-import { fetchTasks } from '../api/taskApi';
+import { DragDropContext } from '@hello-pangea/dnd';
+import { fetchTasks, toggleComplete, reorderTasks } from '../api/taskApi';
 import Column from './Column';
 import TaskForm from './TaskForm';
 
@@ -12,13 +13,61 @@ function Board() {
 
   useEffect(() => {
     fetchTasks()
-      .then(setTasks)
+      .then((data) => {
+        const sorted = [...data].sort((a, b) => a.sortOrder - b.sortOrder);
+        setTasks(sorted);
+      })
       .catch(() => setError('タスクの取得に失敗しました。'))
       .finally(() => setLoading(false));
   }, []);
 
   const handleTaskCreated = (newTask) => {
     setTasks((prev) => [...prev, newTask]);
+  };
+
+  const handleToggleComplete = (id) => {
+    toggleComplete(id)
+      .then((updated) => {
+        setTasks((prev) => prev.map((t) => (t.id === updated.id ? updated : t)));
+      })
+      .catch(() => alert('完了状態の更新に失敗しました。'));
+  };
+
+  const handleDragEnd = (result) => {
+    const { source, destination } = result;
+    if (!destination) return;
+    if (source.droppableId === destination.droppableId && source.index === destination.index) return;
+
+    const sourceGenre = source.droppableId;
+    const destGenre = destination.droppableId;
+
+    setTasks((prev) => {
+      const matchesGenre = (task, genre) =>
+        genre === '未設定' ? !task.genre || task.genre === '未設定' : task.genre === genre;
+
+      const sourceTasks = prev.filter((t) => matchesGenre(t, sourceGenre)).map((t) => ({ ...t }));
+      const destTasks =
+        sourceGenre === destGenre
+          ? sourceTasks
+          : prev.filter((t) => matchesGenre(t, destGenre)).map((t) => ({ ...t }));
+
+      const [moved] = sourceTasks.splice(source.index, 1);
+      moved.genre = destGenre === '未設定' ? null : destGenre;
+      destTasks.splice(destination.index, 0, moved);
+
+      sourceTasks.forEach((t, i) => { t.sortOrder = i; });
+      if (sourceGenre !== destGenre) {
+        destTasks.forEach((t, i) => { t.sortOrder = i; });
+      }
+
+      const changedTasks = sourceGenre === destGenre ? sourceTasks : [...sourceTasks, ...destTasks];
+      reorderTasks(changedTasks.map((t) => ({ id: t.id, sortOrder: t.sortOrder, genre: t.genre })))
+        .catch(() => alert('並び替えの保存に失敗しました。'));
+
+      const changedIds = new Set(changedTasks.map((t) => t.id));
+      const unchanged = prev.filter((t) => !changedIds.has(t.id));
+      return [...unchanged, ...changedTasks].sort((a, b) => a.sortOrder - b.sortOrder);
+    });
   };
 
   if (loading) return <p className="board-message">読み込み中...</p>;
@@ -34,11 +83,18 @@ function Board() {
   return (
     <div className="board-container">
       <TaskForm onCreated={handleTaskCreated} />
-      <div className="board">
-        {GENRES.map((genre) => (
-          <Column key={genre} genre={genre} tasks={tasksByGenre[genre]} />
-        ))}
-      </div>
+      <DragDropContext onDragEnd={handleDragEnd}>
+        <div className="board">
+          {GENRES.map((genre) => (
+            <Column
+              key={genre}
+              genre={genre}
+              tasks={tasksByGenre[genre]}
+              onToggleComplete={handleToggleComplete}
+            />
+          ))}
+        </div>
+      </DragDropContext>
     </div>
   );
 }

--- a/frontend/src/components/Column.jsx
+++ b/frontend/src/components/Column.jsx
@@ -1,20 +1,35 @@
+import { Droppable } from '@hello-pangea/dnd';
 import TaskCard from './TaskCard';
 
-function Column({ genre, tasks }) {
+function Column({ genre, tasks, onToggleComplete }) {
   return (
     <div className="column">
       <div className="column-header">
         <span className="column-title">{genre}</span>
         <span className="column-count">{tasks.length}</span>
       </div>
-      <div className="column-body">
-        {tasks.map((task) => (
-          <TaskCard key={task.id} task={task} />
-        ))}
-        {tasks.length === 0 && (
-          <p className="column-empty">タスクがありません</p>
+      <Droppable droppableId={genre}>
+        {(provided, snapshot) => (
+          <div
+            className={`column-body${snapshot.isDraggingOver ? ' drag-over' : ''}`}
+            ref={provided.innerRef}
+            {...provided.droppableProps}
+          >
+            {tasks.map((task, index) => (
+              <TaskCard
+                key={task.id}
+                task={task}
+                index={index}
+                onToggleComplete={onToggleComplete}
+              />
+            ))}
+            {provided.placeholder}
+            {tasks.length === 0 && !snapshot.isDraggingOver && (
+              <p className="column-empty">タスクがありません</p>
+            )}
+          </div>
         )}
-      </div>
+      </Droppable>
     </div>
   );
 }

--- a/frontend/src/components/TaskCard.jsx
+++ b/frontend/src/components/TaskCard.jsx
@@ -1,4 +1,6 @@
-function TaskCard({ task }) {
+import { Draggable } from '@hello-pangea/dnd';
+
+function TaskCard({ task, index, onToggleComplete }) {
   const today = new Date();
   today.setHours(0, 0, 0, 0);
 
@@ -15,13 +17,31 @@ function TaskCard({ task }) {
   }
 
   return (
-    <div className={`task-card${task.completed ? ' completed' : ''}`}>
-      <p className="task-title">{task.title}</p>
-      {task.memo && <p className="task-memo">{task.memo}</p>}
-      {dueDateLabel && (
-        <p className={`task-due ${dueDateClass}`}>期限: {dueDateLabel}</p>
+    <Draggable draggableId={String(task.id)} index={index}>
+      {(provided, snapshot) => (
+        <div
+          className={`task-card${task.completed ? ' completed' : ''}${snapshot.isDragging ? ' dragging' : ''}`}
+          ref={provided.innerRef}
+          {...provided.draggableProps}
+          {...provided.dragHandleProps}
+        >
+          <div className="task-card-header">
+            <button
+              className={`complete-btn${task.completed ? ' active' : ''}`}
+              onClick={() => onToggleComplete(task.id)}
+              title={task.completed ? '未完了に戻す' : '完了にする'}
+            >
+              {task.completed ? '✓' : '○'}
+            </button>
+            <p className="task-title">{task.title}</p>
+          </div>
+          {task.memo && <p className="task-memo">{task.memo}</p>}
+          {dueDateLabel && (
+            <p className={`task-due ${dueDateClass}`}>期限: {dueDateLabel}</p>
+          )}
+        </div>
       )}
-    </div>
+    </Draggable>
   );
 }
 


### PR DESCRIPTION
## 概要

Closes #19

## 実装内容

### バックエンド
- `PUT /tasks/reorder` エンドポイントを追加
- `ReorderRequest` DTO を新規作成（`id`, `sortOrder`, `genre` を含む）
- `TaskService.reorder()` でジャンル変更も保存するよう対応

### フロントエンド
- `taskApi.js` に `toggleComplete` / `reorderTasks` 関数を追加
- `TaskCard` に完了トグルボタン（○/✓）を追加
- `@hello-pangea/dnd` を導入してドラッグ&ドロップ並び替えを実装
- 同一ジャンル内の並び替え・ジャンルをまたいだ移動の両方に対応
- ページリロード後も並び順・完了状態・ジャンルが維持される

## 動作確認
- [x] 完了ボタンをクリックすると is_completed が切り替わり、見た目に反映される
- [x] カードをドラッグして同一ジャンル内で並び替えると sort_order がDBに保存される
- [x] カードをドラッグして別ジャンルに移動すると genre と sort_order がDBに保存される
- [x] ページリロード後も並び順・完了状態・ジャンルが維持される