### PR TITLE
[#21] タスク詳細・編集モーダルを実装

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -305,3 +305,103 @@ body {
   opacity: 0.6;
   cursor: not-allowed;
 }
+
+/* Modal */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+}
+
+.modal {
+  background: #fff;
+  border-radius: 12px;
+  width: 480px;
+  max-width: calc(100vw - 32px);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+  display: flex;
+  flex-direction: column;
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.modal-title {
+  font-size: 16px;
+  font-weight: 700;
+  color: #111827;
+}
+
+.modal-close {
+  background: none;
+  border: none;
+  font-size: 16px;
+  color: #6b7280;
+  cursor: pointer;
+  padding: 4px;
+  line-height: 1;
+}
+
+.modal-close:hover {
+  color: #111827;
+}
+
+.modal-body {
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px 20px;
+  border-top: 1px solid #e5e7eb;
+}
+
+.modal-cancel {
+  background: #f3f4f6;
+  color: #374151;
+  border: none;
+  border-radius: 6px;
+  padding: 8px 18px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.modal-cancel:hover {
+  background: #e5e7eb;
+}
+
+.modal-save {
+  background: #2563eb;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 8px 18px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.modal-save:hover:not(:disabled) {
+  background: #1d4ed8;
+}
+
+.modal-save:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/frontend/src/api/taskApi.js
+++ b/frontend/src/api/taskApi.js
@@ -7,3 +7,5 @@ export const createTask = (data) => axios.post('/api/tasks', data).then((r) => r
 export const toggleComplete = (id) => axios.patch(`/api/tasks/${id}/complete`).then((r) => r.data);
 
 export const reorderTasks = (items) => axios.put('/api/tasks/reorder', { items });
+
+export const updateTask = (id, data) => axios.put(`/api/tasks/${id}`, data).then((r) => r.data);

--- a/frontend/src/components/Board.jsx
+++ b/frontend/src/components/Board.jsx
@@ -3,6 +3,7 @@ import { DragDropContext } from '@hello-pangea/dnd';
 import { fetchTasks, toggleComplete, reorderTasks } from '../api/taskApi';
 import Column from './Column';
 import TaskForm from './TaskForm';
+import TaskDetailModal from './TaskDetailModal';
 
 const GENRES = ['仕事', '家庭', '趣味', '買い物', '未設定'];
 
@@ -10,6 +11,7 @@ function Board() {
   const [tasks, setTasks] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [selectedTask, setSelectedTask] = useState(null);
 
   useEffect(() => {
     fetchTasks()
@@ -23,6 +25,14 @@ function Board() {
 
   const handleTaskCreated = (newTask) => {
     setTasks((prev) => [...prev, newTask]);
+  };
+
+  const handleCardClick = (task) => setSelectedTask(task);
+
+  const handleModalClose = () => setSelectedTask(null);
+
+  const handleTaskUpdated = (updated) => {
+    setTasks((prev) => prev.map((t) => (t.id === updated.id ? updated : t)));
   };
 
   const handleToggleComplete = (id) => {
@@ -91,10 +101,18 @@ function Board() {
               genre={genre}
               tasks={tasksByGenre[genre]}
               onToggleComplete={handleToggleComplete}
+              onCardClick={handleCardClick}
             />
           ))}
         </div>
       </DragDropContext>
+      {selectedTask && (
+        <TaskDetailModal
+          task={selectedTask}
+          onClose={handleModalClose}
+          onUpdated={handleTaskUpdated}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/components/Column.jsx
+++ b/frontend/src/components/Column.jsx
@@ -1,7 +1,7 @@
 import { Droppable } from '@hello-pangea/dnd';
 import TaskCard from './TaskCard';
 
-function Column({ genre, tasks, onToggleComplete }) {
+function Column({ genre, tasks, onToggleComplete, onCardClick }) {
   return (
     <div className="column">
       <div className="column-header">
@@ -21,6 +21,7 @@ function Column({ genre, tasks, onToggleComplete }) {
                 task={task}
                 index={index}
                 onToggleComplete={onToggleComplete}
+                onCardClick={onCardClick}
               />
             ))}
             {provided.placeholder}

--- a/frontend/src/components/TaskCard.jsx
+++ b/frontend/src/components/TaskCard.jsx
@@ -1,6 +1,6 @@
 import { Draggable } from '@hello-pangea/dnd';
 
-function TaskCard({ task, index, onToggleComplete }) {
+function TaskCard({ task, index, onToggleComplete, onCardClick }) {
   const today = new Date();
   today.setHours(0, 0, 0, 0);
 
@@ -24,11 +24,12 @@ function TaskCard({ task, index, onToggleComplete }) {
           ref={provided.innerRef}
           {...provided.draggableProps}
           {...provided.dragHandleProps}
+          onClick={() => onCardClick(task)}
         >
           <div className="task-card-header">
             <button
               className={`complete-btn${task.completed ? ' active' : ''}`}
-              onClick={() => onToggleComplete(task.id)}
+              onClick={(e) => { e.stopPropagation(); onToggleComplete(task.id); }}
               title={task.completed ? '未完了に戻す' : '完了にする'}
             >
               {task.completed ? '✓' : '○'}

--- a/frontend/src/components/TaskDetailModal.jsx
+++ b/frontend/src/components/TaskDetailModal.jsx
@@ -1,0 +1,100 @@
+import { useState } from 'react';
+import { updateTask } from '../api/taskApi';
+
+const GENRES = ['仕事', '家庭', '趣味', '買い物', '未設定'];
+
+function TaskDetailModal({ task, onClose, onUpdated }) {
+  const [title, setTitle] = useState(task.title);
+  const [memo, setMemo] = useState(task.memo || '');
+  const [dueDate, setDueDate] = useState(task.dueDate || '');
+  const [genre, setGenre] = useState(task.genre || '未設定');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+
+  const handleSave = () => {
+    if (!title.trim()) {
+      setError('タイトルは必須です');
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    updateTask(task.id, {
+      title: title.trim(),
+      memo: memo || null,
+      dueDate: dueDate || null,
+      genre: genre === '未設定' ? null : genre,
+      sortOrder: task.sortOrder,
+    })
+      .then((updated) => {
+        onUpdated(updated);
+        onClose();
+      })
+      .catch(() => setError('保存に失敗しました。'))
+      .finally(() => setSaving(false));
+  };
+
+  const handleOverlayClick = (e) => {
+    if (e.target === e.currentTarget) onClose();
+  };
+
+  return (
+    <div className="modal-overlay" onClick={handleOverlayClick}>
+      <div className="modal">
+        <div className="modal-header">
+          <h2 className="modal-title">タスク詳細</h2>
+          <button className="modal-close" onClick={onClose}>✕</button>
+        </div>
+
+        <div className="modal-body">
+          <div className="task-form-field">
+            <label>タイトル <span className="required">*</span></label>
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+            />
+          </div>
+
+          <div className="task-form-field">
+            <label>メモ</label>
+            <textarea
+              rows={3}
+              value={memo}
+              onChange={(e) => setMemo(e.target.value)}
+            />
+          </div>
+
+          <div className="task-form-row">
+            <div className="task-form-field">
+              <label>期限</label>
+              <input
+                type="date"
+                value={dueDate}
+                onChange={(e) => setDueDate(e.target.value)}
+              />
+            </div>
+            <div className="task-form-field">
+              <label>ジャンル</label>
+              <select value={genre} onChange={(e) => setGenre(e.target.value)}>
+                {GENRES.map((g) => (
+                  <option key={g} value={g}>{g}</option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          {error && <p className="task-form-error">{error}</p>}
+        </div>
+
+        <div className="modal-footer">
+          <button className="modal-cancel" onClick={onClose}>キャンセル</button>
+          <button className="modal-save" onClick={handleSave} disabled={saving}>
+            {saving ? '保存中...' : '保存'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default TaskDetailModal;


### PR DESCRIPTION
## 概要

Closes #21

## 実装内容

- `TaskDetailModal` コンポーネントを新規作成
- タスクカードをクリックするとモーダルが開き、現在の値が表示される
- モーダル内でタイトル・メモ・期限・ジャンルを編集して保存できる
- `PUT /tasks/{id}` API と連携し、保存後にカードの表示を即時更新
- オーバーレイ（背景の暗い部分）または ✕ ボタンでモーダルを閉じる
- 完了ボタンクリック時はモーダルが開かないよう `stopPropagation` を追加

## 動作確認
- [x] タスクカードをクリックするとモーダルが開き、現在の値が表示される
- [x] 内容を編集して保存するとカードの表示が更新される
- [x] ✕ボタン・背景クリックでモーダルが閉じる
- [x] 完了ボタンクリック時はモーダルが開かない