### PR TITLE
[#23] タスク詳細モーダルに物理削除機能を追加

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -364,10 +364,32 @@ body {
 
 .modal-footer {
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
+  align-items: center;
   gap: 8px;
   padding: 12px 20px;
   border-top: 1px solid #e5e7eb;
+}
+
+.modal-footer-right {
+  display: flex;
+  gap: 8px;
+}
+
+.modal-delete {
+  background: #fee2e2;
+  color: #dc2626;
+  border: none;
+  border-radius: 6px;
+  padding: 8px 18px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.modal-delete:hover {
+  background: #fecaca;
 }
 
 .modal-cancel {

--- a/frontend/src/api/taskApi.js
+++ b/frontend/src/api/taskApi.js
@@ -9,3 +9,5 @@ export const toggleComplete = (id) => axios.patch(`/api/tasks/${id}/complete`).t
 export const reorderTasks = (items) => axios.put('/api/tasks/reorder', { items });
 
 export const updateTask = (id, data) => axios.put(`/api/tasks/${id}`, data).then((r) => r.data);
+
+export const deleteTask = (id) => axios.delete(`/api/tasks/${id}`);

--- a/frontend/src/components/Board.jsx
+++ b/frontend/src/components/Board.jsx
@@ -35,6 +35,10 @@ function Board() {
     setTasks((prev) => prev.map((t) => (t.id === updated.id ? updated : t)));
   };
 
+  const handleTaskDeleted = (id) => {
+    setTasks((prev) => prev.filter((t) => t.id !== id));
+  };
+
   const handleToggleComplete = (id) => {
     toggleComplete(id)
       .then((updated) => {
@@ -111,6 +115,7 @@ function Board() {
           task={selectedTask}
           onClose={handleModalClose}
           onUpdated={handleTaskUpdated}
+          onDeleted={handleTaskDeleted}
         />
       )}
     </div>

--- a/frontend/src/components/TaskDetailModal.jsx
+++ b/frontend/src/components/TaskDetailModal.jsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
-import { updateTask } from '../api/taskApi';
+import { updateTask, deleteTask } from '../api/taskApi';
 
 const GENRES = ['仕事', '家庭', '趣味', '買い物', '未設定'];
 
-function TaskDetailModal({ task, onClose, onUpdated }) {
+function TaskDetailModal({ task, onClose, onUpdated, onDeleted }) {
   const [title, setTitle] = useState(task.title);
   const [memo, setMemo] = useState(task.memo || '');
   const [dueDate, setDueDate] = useState(task.dueDate || '');
@@ -31,6 +31,16 @@ function TaskDetailModal({ task, onClose, onUpdated }) {
       })
       .catch(() => setError('保存に失敗しました。'))
       .finally(() => setSaving(false));
+  };
+
+  const handleDelete = () => {
+    if (!window.confirm(`「${task.title}」を削除しますか？この操作は元に戻せません。`)) return;
+    deleteTask(task.id)
+      .then(() => {
+        onDeleted(task.id);
+        onClose();
+      })
+      .catch(() => setError('削除に失敗しました。'));
   };
 
   const handleOverlayClick = (e) => {
@@ -87,10 +97,13 @@ function TaskDetailModal({ task, onClose, onUpdated }) {
         </div>
 
         <div className="modal-footer">
-          <button className="modal-cancel" onClick={onClose}>キャンセル</button>
-          <button className="modal-save" onClick={handleSave} disabled={saving}>
-            {saving ? '保存中...' : '保存'}
-          </button>
+          <button className="modal-delete" onClick={handleDelete}>削除</button>
+          <div className="modal-footer-right">
+            <button className="modal-cancel" onClick={onClose}>キャンセル</button>
+            <button className="modal-save" onClick={handleSave} disabled={saving}>
+              {saving ? '保存中...' : '保存'}
+            </button>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 概要
タスク詳細モーダルから、タスクを物理削除できる機能を追加しました。

## 変更内容
- `taskApi.js`: `deleteTask` 関数を追加（`DELETE /api/tasks/{id}` を呼び出す）
- `TaskDetailModal.jsx`: 削除ボタンを追加。押下時に確認ダイアログを表示し、確認後に物理削除
- `Board.jsx`: `handleTaskDeleted` ハンドラを追加し、削除後にステートから該当タスクを除去
- `App.css`: 削除ボタンのスタイル（赤系）と `modal-footer` のレイアウト調整

## 動作
1. タスクカードをクリックして詳細モーダルを開く
2. モーダル左下の「削除」ボタンを押す
3. 確認ダイアログが表示される（「この操作は元に戻せません」）
4. OKを押すと `DELETE /api/tasks/{id}` が呼ばれ DB から物理削除
5. モーダルが閉じ、ボードからタスクカードが消える

## 備考
バックエンドの `DELETE /api/tasks/{id}` は実装済みのため、フロントエンドのみ変更。

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)