### PR TITLE
[#25] タスク追加フォームをタスク一覧の下に移動

### DIFF
--- a/frontend/src/components/Board.jsx
+++ b/frontend/src/components/Board.jsx
@@ -92,7 +92,6 @@ function Board() {
 
   return (
     <div className="board-container">
-      <TaskForm onCreated={handleTaskCreated} />
       <DragDropContext onDragEnd={handleDragEnd}>
         <div className="board">
           {GENRES.map((genre) => (
@@ -113,6 +112,7 @@ function Board() {
           onUpdated={handleTaskUpdated}
         />
       )}
+      <TaskForm onCreated={handleTaskCreated} />
     </div>
   );
 }


### PR DESCRIPTION
## 概要
ページ上部にあったタスク追加フォームを、タスク一覧（ボード）の下に移動しました。

## 変更内容
- `Board.jsx`: `<TaskForm>` を `<DragDropContext>` の前から後ろに移動（1行変更）

## 理由
ユーザーはアプリを開いたとき、まず既存タスクの一覧を確認したい。フォームが上にあると一覧がスクロールしないと見えないため、UX改善として一覧を先に表示する。

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)